### PR TITLE
Add Postgres database and DB-backed endpoints

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,9 @@ pipeline {
                         return
                     }
 
+                    // 📡 Ensure a dedicated network exists for inter-service communication
+                    sh 'docker network create ci-network || true'
+
                     // 🔁 Iterate over each changed service
                     for (service in changedServices) {
                         def serviceDir = "services/${service}"
@@ -71,7 +74,7 @@ pipeline {
                                 docker stop ${containerName} || true
                                 docker rm ${containerName} || true
                                 echo "🛠️ Running container ${containerName} from image ${image}"
-                                docker run -d --restart unless-stopped --name ${containerName} ${portFlags} ${envFlags} ${image}
+                                docker run -d --restart unless-stopped --name ${containerName} --network ci-network ${portFlags} ${envFlags} ${image}
                             """
 
                             echo "✅ ${containerName} deployed"

--- a/README.md
+++ b/README.md
@@ -10,3 +10,12 @@ deploy-repo/
 ├── Jenkinsfile
 └── README.md
 
+## Handler service and Postgres database
+
+The `handler` service now stores messages in a Postgres container. Two new endpoints were added:
+
+* `POST /tools/messages` – store a message.
+* `GET /tools/messages/{id}` – retrieve a stored message.
+
+The Postgres container is defined under `services/postgres` and both services run on the same Docker network created by the Jenkins pipeline.
+

--- a/services/handler/app/db.py
+++ b/services/handler/app/db.py
@@ -1,0 +1,24 @@
+import os
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker, DeclarativeBase, Mapped, mapped_column
+from sqlalchemy import Integer, Text
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql+asyncpg://postgres:postgres@postgres:5432/handler_db",
+)
+
+engine = create_async_engine(DATABASE_URL, echo=False)
+SessionLocal = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+class Base(DeclarativeBase):
+    pass
+
+class Message(Base):
+    __tablename__ = "messages"
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    content: Mapped[str] = mapped_column(Text)
+
+async def init_db() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)

--- a/services/handler/app/main.py
+++ b/services/handler/app/main.py
@@ -1,5 +1,11 @@
 from fastapi import FastAPI
 from app.routes import tools
+from app.db import init_db
 
 app = FastAPI()
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    await init_db()
+
 app.include_router(tools.router, prefix="/tools")

--- a/services/handler/app/routes/tools.py
+++ b/services/handler/app/routes/tools.py
@@ -1,9 +1,16 @@
-from fastapi import APIRouter
-from app.schemas.tool_request import ToolRequest
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import HTMLResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+from app.schemas.tool_request import ToolRequest
 from app.tools.echo import echo_message
+from app.db import SessionLocal, Message
 
 router = APIRouter()
+
+async def get_db() -> AsyncSession:
+    async with SessionLocal() as session:
+        yield session
 
 @router.post("/echo")
 async def run_echo(req: ToolRequest):
@@ -22,3 +29,19 @@ async def echo():
         </body>
     </html>
     """
+
+@router.post("/messages")
+async def create_message(req: ToolRequest, db: AsyncSession = Depends(get_db)):
+    msg = Message(content=req.message)
+    db.add(msg)
+    await db.commit()
+    await db.refresh(msg)
+    return {"id": msg.id, "message": msg.content}
+
+@router.get("/messages/{msg_id}")
+async def read_message(msg_id: int, db: AsyncSession = Depends(get_db)):
+    result = await db.execute(select(Message).where(Message.id == msg_id))
+    msg = result.scalar_one_or_none()
+    if not msg:
+        raise HTTPException(status_code=404, detail="Message not found")
+    return {"id": msg.id, "message": msg.content}

--- a/services/handler/deploy.json
+++ b/services/handler/deploy.json
@@ -1,8 +1,11 @@
 {
   "image": "python-test-image:latest",
   "build": true,
-  "ports": ["8082:8000"],
+  "ports": [
+    "8082:8000"
+  ],
   "env": {
-    "GLOBAL_MESSAGE": "Hello from Jenkins!!"
+    "GLOBAL_MESSAGE": "Hello from Jenkins!!",
+    "DATABASE_URL": "postgresql+asyncpg://postgres:postgres@postgres:5432/handler_db"
   }
 }

--- a/services/handler/requirements.txt
+++ b/services/handler/requirements.txt
@@ -1,3 +1,5 @@
 fastapi
 uvicorn
 pydantic
+sqlalchemy
+asyncpg

--- a/services/postgres/deploy.json
+++ b/services/postgres/deploy.json
@@ -1,0 +1,8 @@
+{
+  "image": "postgres:15",
+  "ports": ["5432:5432"],
+  "env": {
+    "POSTGRES_PASSWORD": "postgres",
+    "POSTGRES_DB": "handler_db"
+  }
+}


### PR DESCRIPTION
## Summary
- build a Postgres service alongside the handler API
- allow the handler API to connect to Postgres
- save and retrieve messages with new endpoints
- create a Docker network in the Jenkins pipeline so services can talk to each other
- document the new setup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684bd37cb720832cabb4e79d531fd1c1