### PR TITLE
Improve DB init

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,10 @@ The handler container runs a FastAPI app on port `8000` (mapped to `8082` on the
 The Postgres container provides the database `handler_db` and is configured with the `POSTGRES_PASSWORD` environment variable set to `postgres`.
 
 Both containers run on the same Docker network created by Jenkins so the handler service can reach the database at the hostname `postgres`.
+
+### Database Initialisation
+
+The FastAPI application automatically creates the required tables when it
+starts. If the database is not ready yet, the startup routine retries a few
+times before giving up. Simply running the `handler` service prepares the
+database for storing messages.


### PR DESCRIPTION
## Summary
- add retries in `init_db` so the handler waits for Postgres
- document automatic DB initialization in the README

## Testing
- `python -m py_compile services/handler/app/db.py services/handler/app/main.py services/handler/app/routes/tools.py`

------
https://chatgpt.com/codex/tasks/task_e_684c0aeb855c832c98a309c2dd5a082b