### PR TITLE
Add OpenAPI schema tool to MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ feature:
   vehicle brand and model.
 - `GET /tools/schema` – returns the OpenAI tool schema describing
   `get_vehicle_price`.
+- `GET /openapi.json` – returns an OpenAPI description of the
+  `get_vehicle_price` tool.
 
 These endpoints are intentionally lightweight so you can easily connect to them
 from the ChatGPT playground or your own scripts while learning how MCP works.

--- a/services/mcp_server/app/main.py
+++ b/services/mcp_server/app/main.py
@@ -1,8 +1,10 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
-from app.tools import router as tools_router
+from app.tools import router as tools_router, OPENAPI_SCHEMA
 
-app = FastAPI(title="Dummy MCP Server")
+# Disable FastAPI's default OpenAPI endpoint so we can serve a custom schema
+# describing only the available tool.
+app = FastAPI(title="Dummy MCP Server", openapi_url=None)
 
 class EchoRequest(BaseModel):
     message: str
@@ -22,3 +24,9 @@ async def echo(req: EchoRequest) -> dict:
 
 
 app.include_router(tools_router, prefix="/tools")
+
+
+# Expose the minimal OpenAPI schema so agents can discover the tool
+@app.get("/openapi.json", include_in_schema=False)
+async def openapi() -> dict:
+    return OPENAPI_SCHEMA

--- a/services/mcp_server/app/tools.py
+++ b/services/mcp_server/app/tools.py
@@ -24,6 +24,51 @@ TOOL_SCHEMA = {
     }
 }
 
+# Minimal OpenAPI schema describing the available tool.
+OPENAPI_SCHEMA = {
+    "openapi": "3.0.1",
+    "info": {"title": "Vehicle Price API", "version": "1.0.0"},
+    "paths": {
+        "/tools/get_vehicle_price": {
+            "post": {
+                "operationId": "get_vehicle_price",
+                "description": "Returns vehicle price given brand and model",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "brand": {"type": "string"},
+                                    "model": {"type": "string"}
+                                },
+                                "required": ["brand", "model"]
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "brand": {"type": "string"},
+                                        "model": {"type": "string"},
+                                        "price_eur": {"type": "integer"}
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 @router.post("/get_vehicle_price")
 async def get_vehicle_price(data: VehicleRequest) -> dict:
     price = random.randint(15000, 45000)


### PR DESCRIPTION
## Summary
- expose a minimal OpenAPI spec for the vehicle price tool
- disable FastAPI's default OpenAPI route and serve the custom schema
- document the new `/openapi.json` endpoint in the repository README

## Testing
- `python -m py_compile services/mcp_server/app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684c290f6f6c832cbe1cefcc3a19636a