### PR TITLE
Add nginx proxy and persistent volumes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,13 @@ pipeline {
                         def portFlags = config.ports.collect { "-p ${it}" }.join(" ")
 
                         // ✅ Quote environment values to handle spaces or special characters
-                        def envFlags = config.env.collect { "-e \"${it.key}=${it.value}\"" }.join(" ")
+                        def envFlags = config.containsKey('env') ? config.env.collect { "-e \"${it.key}=${it.value}\"" }.join(" ") : ''
+
+                        // 💾 Mount host volumes when defined
+                        def volumeFlags = ''
+                        if (config.containsKey('volumes')) {
+                            volumeFlags = config.volumes.collect { "-v ${it.key}:${it.value}" }.join(' ')
+                        }
 
                         // 🏗️ Determine if the image needs to be built locally
                         def shouldBuild = config.containsKey("build") && config.build == true
@@ -74,7 +80,7 @@ pipeline {
                                 docker stop ${containerName} || true
                                 docker rm ${containerName} || true
                                 echo "🛠️ Running container ${containerName} from image ${image}"
-                                docker run -d --restart unless-stopped --name ${containerName} --network ci-network ${portFlags} ${envFlags} ${image}
+                                docker run -d --restart unless-stopped --name ${containerName} --network ci-network ${portFlags} ${envFlags} ${volumeFlags} ${image}
                             """
 
                             echo "✅ ${containerName} deployed"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ Deploy/
 │   │   ├── Dockerfile
 │   │   ├── deploy.json
 │   │   └── app/
+│   ├── mcp_server/     # Dummy MCP server
+│   │   ├── Dockerfile
+│   │   ├── deploy.json
+│   │   └── app/
+│   ├── nginx/          # Reverse proxy
+│   │   ├── Dockerfile
+│   │   ├── deploy.json
+│   │   └── nginx.conf
 │   └── postgres/       # Postgres database
 │       └── deploy.json
 ├── Jenkinsfile         # CI/CD pipeline
@@ -26,6 +34,11 @@ The pipeline defined in `Jenkinsfile` creates a shared Docker network (`ci-netwo
 | **handler** | `8082:8000` | FastAPI application exposing the API described below. |
 | **postgres** | `5432:5432` | PostgreSQL 15 database used by the handler service. |
 | **mcp_server** | `8090:8000` | Dummy MCP server for experimenting with OpenAI agents. |
+| **nginx** | `8080:80` | Reverse proxy logging requests and forwarding `/api` to the handler and `/mcp` to the MCP server. |
+
+### Persistent Storage
+
+All containers store data under `/var/ci_data` on the host. For example, the Postgres database is kept in `/var/ci_data/postgres/data` and Nginx writes request logs to `/var/ci_data/nginx/logs`. Mount paths are defined in each service's `deploy.json`.
 
 ### Handler API
 

--- a/services/nginx/Dockerfile
+++ b/services/nginx/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:alpine
+COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/services/nginx/deploy.json
+++ b/services/nginx/deploy.json
@@ -1,0 +1,8 @@
+{
+  "image": "custom-nginx:latest",
+  "build": true,
+  "ports": ["8080:80"],
+  "volumes": {
+    "/var/ci_data/nginx/logs": "/var/log/nginx"
+  }
+}

--- a/services/nginx/nginx.conf
+++ b/services/nginx/nginx.conf
@@ -1,0 +1,19 @@
+server {
+    listen 80;
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log;
+
+    location /api/ {
+        proxy_pass http://handler:8000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    location /mcp/ {
+        proxy_pass http://mcp_server:8000/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+}

--- a/services/postgres/deploy.json
+++ b/services/postgres/deploy.json
@@ -4,5 +4,8 @@
   "env": {
     "POSTGRES_PASSWORD": "postgres",
     "POSTGRES_DB": "handler_db"
+  },
+  "volumes": {
+    "/var/ci_data/postgres/data": "/var/lib/postgresql/data"
   }
 }


### PR DESCRIPTION
## Summary
- deploy an nginx reverse proxy service
- allow persistent volume mounts in the Jenkins pipeline
- persist Postgres data
- document nginx and persistent storage

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684c2fa329c0832cb50691ba48ccb362