### PR TITLE
Fix nginx port and document dependencies

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,6 +47,17 @@ pipeline {
                             volumeFlags = config.volumes.collect { "-v ${it.key}:${it.value}" }.join(' ')
                         }
 
+                        // 📦 Start any container dependencies if defined
+                        if (config.containsKey('depends_on')) {
+                            for (dep in config.depends_on) {
+                                def running = sh(script: "docker ps --filter 'name=${dep}' -q", returnStdout: true).trim()
+                                if (!running) {
+                                    echo "🔗 Starting dependency ${dep}"
+                                    sh "docker start ${dep} || true"
+                                }
+                            }
+                        }
+
                         // 🏗️ Determine if the image needs to be built locally
                         def shouldBuild = config.containsKey("build") && config.build == true
 

--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ The pipeline defined in `Jenkinsfile` creates a shared Docker network (`ci-netwo
 
 ## Deployed Containers
 
-| Container | Ports | Purpose |
-|-----------|-------|---------|
-| **handler** | `8082:8000` | FastAPI application exposing the API described below. |
-| **postgres** | `5432:5432` | PostgreSQL 15 database used by the handler service. |
-| **mcp_server** | `8090:8000` | Dummy MCP server for experimenting with OpenAI agents. |
-| **nginx** | `8080:80` | Reverse proxy logging requests and forwarding `/api` to the handler and `/mcp` to the MCP server. |
+| Container | Ports | Depends On | Purpose |
+|-----------|-------|-----------|---------|
+| **handler** | `8082:8000` | `postgres` | FastAPI application exposing the API described below. |
+| **postgres** | `5432:5432` | `-` | PostgreSQL 15 database used by the handler service. |
+| **mcp_server** | `8090:8000` | `-` | Dummy MCP server for experimenting with OpenAI agents. |
+| **nginx** | `8081:80` | `handler`, `mcp_server` | Reverse proxy logging requests and forwarding `/api` to the handler and `/mcp` to the MCP server. |
 
 ### Persistent Storage
 

--- a/services/handler/deploy.json
+++ b/services/handler/deploy.json
@@ -7,5 +7,6 @@
   "env": {
     "GLOBAL_MESSAGE": "Hello from Jenkins!!",
     "DATABASE_URL": "postgresql+asyncpg://postgres:postgres@postgres:5432/handler_db"
-  }
+  },
+  "depends_on": ["postgres"]
 }

--- a/services/nginx/deploy.json
+++ b/services/nginx/deploy.json
@@ -1,8 +1,9 @@
 {
   "image": "custom-nginx:latest",
   "build": true,
-  "ports": ["8080:80"],
+  "ports": ["8081:80"],
   "volumes": {
     "/var/ci_data/nginx/logs": "/var/log/nginx"
-  }
+  },
+  "depends_on": ["handler", "mcp_server"]
 }


### PR DESCRIPTION
## Summary
- free up port 8080 by using 8081 for nginx
- list container dependencies in the README
- note required dependencies in deploy configs
- start any dependency containers in Jenkinsfile

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `jq empty services/nginx/deploy.json`
- `jq empty services/handler/deploy.json`
- `jq empty services/mcp_server/deploy.json`
- `jq empty services/postgres/deploy.json`


------
https://chatgpt.com/codex/tasks/task_e_684c3b9812dc832c962ec083ccb7981f