### PR TITLE
Generate MCP tools from OpenAPI

### DIFF
--- a/services/mcp_server/README.md
+++ b/services/mcp_server/README.md
@@ -1,6 +1,6 @@
 # MCP Server
 
-`mcp_server` provides a minimal FastAPI application used for experimenting with OpenAI agent tools. It is built locally as `mcp-test-server:latest` and runs on port **8000** (exposed on the host as `8090`).
+`mcp_server` provides a minimal FastAPI application used for experimenting with OpenAI agent tools. It is built locally as `mcp-test-server:latest` and runs on port **8000** (exposed on the host as `8090`). The tool definitions returned by `/tools/schema` are generated from the server's OpenAPI spec at runtime.
 
 The container does not require any environment variables or persistent volumes, but it depends on the `nginx` container for routing.
 
@@ -9,7 +9,7 @@ The container does not require any environment variables or persistent volumes, 
 - `GET /agent/ping` – simple health check returning `{"pong": true}`.
 - `POST /agent/echo` – echoes the received message.
 - `POST /tools/get_vehicle_price` – returns a random price for the given vehicle brand and model.
-- `GET /tools/schema` – returns the OpenAI tool definition for `get_vehicle_price`.
+- `GET /tools/schema` – returns the MCP tool definition derived from the OpenAPI spec.
 - `GET /openapi.json` – minimal OpenAPI schema describing the tool.
 - `GET /.well-known/ai-plugin.json` – plugin manifest used by OpenAI clients.
 

--- a/services/mcp_server/app/tools.py
+++ b/services/mcp_server/app/tools.py
@@ -2,48 +2,92 @@ from fastapi import APIRouter
 from pydantic import BaseModel
 import random
 
+
+def openapi_to_mcp(schema: dict) -> dict:
+    """Convert an OpenAPI schema to a minimal MCP tool definition."""
+    tools = []
+    title = schema.get("info", {}).get("title", "")
+    for path, methods in schema.get("paths", {}).items():
+        for method, op in methods.items():
+            name = op.get("operationId") or f"{method}_{path.strip('/').replace('/', '_')}"
+            description = op.get("description") or op.get("summary", "")
+
+            input_schema = {}
+            if "requestBody" in op:
+                content = op["requestBody"].get("content", {})
+                input_schema = content.get("application/json", {}).get("schema", {})
+            elif "parameters" in op:
+                props = {}
+                required = []
+                for p in op["parameters"]:
+                    schema_ = p.get("schema", {}).copy()
+                    if p.get("description"):
+                        schema_["description"] = p["description"]
+                    props[p["name"]] = schema_
+                    if p.get("required"):
+                        required.append(p["name"])
+                if props:
+                    input_schema = {"type": "object", "properties": props}
+                    if required:
+                        input_schema["required"] = required
+
+            tools.append(
+                {
+                    "name": name,
+                    "description": description,
+                    "inputSchema": input_schema,
+                    "annotations": {"title": title},
+                }
+            )
+
+    return {"tools": tools}
+
 router = APIRouter()
 
 class VehicleRequest(BaseModel):
     brand: str
     model: str
 
-TOOL_SCHEMA = {
-    "type": "function",
-    "function": {
-        "name": "get_vehicle_price",
-        "description": "Returns the market price of a vehicle based on brand and model",
-        "parameters": {
-            "type": "object",
-            "properties": {
-                "brand": {"type": "string", "description": "Vehicle brand (e.g. Skoda)"},
-                "model": {"type": "string", "description": "Vehicle model (e.g. Octavia)"}
-            },
-            "required": ["brand", "model"]
-        }
-    }
-}
-
 # Minimal OpenAPI schema describing the available tool.
 OPENAPI_SCHEMA = {
-    "openapi": "3.0.1",
-    "info": {"title": "Vehicle Price API", "version": "1.0.0"},
+    "openapi": "3.0.3",
+    "info": {
+        "title": "Vehicle Price API",
+        "description": "API to estimate vehicle prices by brand and model.",
+        "version": "1.0.0",
+        "contact": {
+            "name": "API Support",
+            "email": "support@yourdomain.com",
+            "url": "http://yourdomain.com/support",
+        },
+    },
+    "externalDocs": {
+        "description": "Full documentation",
+        "url": "http://yourdomain.com/docs",
+    },
     "servers": [{"url": "http://31.97.45.128:8090"}],
     "paths": {
         "/tools/get_vehicle_price": {
             "post": {
                 "operationId": "get_vehicle_price",
-                "description": "Returns vehicle price given brand and model",
+                "summary": "Get vehicle price estimate",
+                "description": "Returns vehicle price for the provided brand and model",
                 "requestBody": {
                     "content": {
                         "application/json": {
                             "schema": {
                                 "type": "object",
                                 "properties": {
-                                    "brand": {"type": "string"},
-                                    "model": {"type": "string"}
+                                    "brand": {
+                                        "type": "string",
+                                        "description": "Vehicle brand (e.g. Skoda)",
+                                    },
+                                    "model": {
+                                        "type": "string",
+                                        "description": "Vehicle model (e.g. Octavia)",
+                                    },
                                 },
-                                "required": ["brand", "model"]
+                                "required": ["brand", "model"],
                             }
                         }
                     }
@@ -83,6 +127,8 @@ AI_PLUGIN_SCHEMA = {
     "legal_info_url": "http://yourdomain.com/legal"
 }
 
+TOOLS = openapi_to_mcp(OPENAPI_SCHEMA)["tools"]
+
 @router.post("/get_vehicle_price")
 async def get_vehicle_price(data: VehicleRequest) -> dict:
     price = random.randint(15000, 45000)
@@ -94,6 +140,6 @@ async def get_vehicle_price(data: VehicleRequest) -> dict:
 
 @router.get("/schema")
 async def get_schema() -> dict:
-    """Return the OpenAI tool definition."""
-    return {"tools": [TOOL_SCHEMA]}
+    """Return the MCP tool definition generated from the OpenAPI schema."""
+    return {"tools": TOOLS}
 


### PR DESCRIPTION
## Summary
- extend `mcp_server` OpenAPI schema with more descriptive metadata
- add helper to convert an OpenAPI schema into MCP tool definitions
- serve generated tool definition from `/schema`
- document runtime generation of tools in service README

## Testing
- `python -m py_compile services/mcp_server/app/tools.py`


------
https://chatgpt.com/codex/tasks/task_e_684caedc3a88832ca8daf23d2ad96b17