### PR TITLE
Fix MCP server dependency error

### DIFF
--- a/services/mcp_server/README.md
+++ b/services/mcp_server/README.md
@@ -2,7 +2,11 @@
 
 `mcp_server` provides a minimal FastAPI application used for experimenting with OpenAI agent tools. It is built locally as `mcp-test-server:latest` and runs on port **8000** (exposed on the host as `8090`). The tool definitions returned by `/tools/schema` are generated from the server's OpenAPI spec at runtime.
 
-The container does not require any environment variables or persistent volumes, but it depends on the `nginx` container for routing.
+The container exposes the base URL used in its OpenAPI schema via the
+`BASE_URL` environment variable (default: `http://localhost:8090`).  This
+allows the service to operate correctly regardless of the host's IP address.
+It has no other required environment variables or persistent volumes, but it
+depends on the `nginx` container for routing.
 
 ## Endpoints
 

--- a/services/mcp_server/app/tools.py
+++ b/services/mcp_server/app/tools.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
 import random
+import os
 
 
 def openapi_to_mcp(schema: dict) -> dict:
@@ -49,6 +50,8 @@ class VehicleRequest(BaseModel):
     model: str
 
 # Minimal OpenAPI schema describing the available tool.
+BASE_URL = os.getenv("BASE_URL", "http://localhost:8090")
+
 OPENAPI_SCHEMA = {
     "openapi": "3.0.3",
     "info": {
@@ -65,7 +68,7 @@ OPENAPI_SCHEMA = {
         "description": "Full documentation",
         "url": "http://yourdomain.com/docs",
     },
-    "servers": [{"url": "http://31.97.45.128:8090"}],
+    "servers": [{"url": BASE_URL}],
     "paths": {
         "/tools/get_vehicle_price": {
             "post": {
@@ -121,8 +124,8 @@ AI_PLUGIN_SCHEMA = {
     "description_for_human": "Get price estimate for a vehicle given brand and model",
     "description_for_model": "Use this tool to retrieve vehicle pricing by brand and model",
     "auth": {"type": "none"},
-    "api": {"type": "openapi", "url": "http://31.97.45.128:8090/openapi.json"},
-    "logo_url": "http://31.97.45.128:8090/logo.png",
+    "api": {"type": "openapi", "url": f"{BASE_URL}/openapi.json"},
+    "logo_url": f"{BASE_URL}/logo.png",
     "contact_email": "support@yourdomain.com",
     "legal_info_url": "http://yourdomain.com/legal"
 }

--- a/services/mcp_server/deploy.json
+++ b/services/mcp_server/deploy.json
@@ -2,5 +2,8 @@
   "image": "mcp-test-server:latest",
   "build": true,
   "ports": ["8090:8000"],
+  "env": {
+    "BASE_URL": "http://localhost:8090"
+  },
   "depends_on": ["nginx"]
 }


### PR DESCRIPTION
## Summary
- make base URL configurable for mcp_server
- document the `BASE_URL` environment variable
- set default env in `deploy.json`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m uvicorn app.main:app --port 8000 --app-dir services/mcp_server` (manual)
- `curl http://127.0.0.1:8000/openapi.json`


------
https://chatgpt.com/codex/tasks/task_e_684cb4336ddc832ca38029e5b7ac1a6a