### PR TITLE
Refactor MCP server to follow OpenAI MCP spec

### DIFF
--- a/services/mcp_server/README.md
+++ b/services/mcp_server/README.md
@@ -1,6 +1,6 @@
 # MCP Server
 
-`mcp_server` provides a minimal FastAPI application used for experimenting with OpenAI agent tools. It is built locally as `mcp-test-server:latest` and runs on port **8000** (exposed on the host as `8090`). The tool definitions returned by `/tools/schema` are generated from the server's OpenAPI spec at runtime.
+`mcp_server` exposes a small FastAPI service that follows the [OpenAI MCP](https://platform.openai.com/docs/mcp) guidelines.  It is built locally as `mcp-test-server:latest` and runs on port **8000** (exposed on the host as `8090`). The tool definition served by `/tools/schema` is derived from the `openapi.json` file at container start.
 
 The container exposes the base URL used in its OpenAPI schema via the
 `BASE_URL` environment variable (default: `http://localhost:8090`).  This
@@ -12,7 +12,7 @@ depends on the `nginx` container for routing.
 
 - `GET /agent/ping` – simple health check returning `{"pong": true}`.
 - `POST /agent/echo` – echoes the received message.
-- `POST /tools/get_vehicle_price` – returns a random price for the given vehicle brand and model.
+- `POST /tools/get_vehicle_price` – returns a price for the given vehicle brand and model. Known vehicles are looked up from a small in-memory table, otherwise a random value is returned.
 - `GET /tools/schema` – returns the MCP tool definition derived from the OpenAPI spec.
 - `GET /openapi.json` – minimal OpenAPI schema describing the tool.
 - `GET /.well-known/ai-plugin.json` – plugin manifest used by OpenAI clients.

--- a/services/mcp_server/app/ai-plugin.json
+++ b/services/mcp_server/app/ai-plugin.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "v1",
+  "name_for_human": "Vehicle Price Tool",
+  "name_for_model": "vehicle_price_api",
+  "description_for_human": "Lookup the price of a vehicle by brand and model",
+  "description_for_model": "Retrieve vehicle pricing information",
+  "auth": {"type": "none"},
+  "api": {"type": "openapi", "url": "http://localhost:8090/openapi.json"},
+  "logo_url": "http://localhost:8090/logo.png",
+  "contact_email": "support@example.com",
+  "legal_info_url": "http://example.com/legal"
+}

--- a/services/mcp_server/app/main.py
+++ b/services/mcp_server/app/main.py
@@ -6,7 +6,7 @@ from app.tools import router as tools_router, OPENAPI_SCHEMA, AI_PLUGIN_SCHEMA
 
 # Disable FastAPI's default OpenAPI endpoint so we can serve a custom schema
 # describing only the available tool.
-app = FastAPI(title="Dummy MCP Server", openapi_url=None)
+app = FastAPI(title="Vehicle Price MCP Server", openapi_url=None)
 
 class EchoRequest(BaseModel):
     message: str

--- a/services/mcp_server/app/openapi.json
+++ b/services/mcp_server/app/openapi.json
@@ -1,0 +1,49 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Vehicle Price API",
+    "description": "API to retrieve prices for vehicles by brand and model.",
+    "version": "1.0.0"
+  },
+  "servers": [{"url": "http://localhost:8090"}],
+  "paths": {
+    "/tools/get_vehicle_price": {
+      "post": {
+        "operationId": "get_vehicle_price",
+        "summary": "Get vehicle price",
+        "description": "Returns a price for the given brand and model.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "brand": {"type": "string", "description": "Vehicle brand"},
+                  "model": {"type": "string", "description": "Vehicle model"}
+                },
+                "required": ["brand", "model"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "brand": {"type": "string"},
+                    "model": {"type": "string"},
+                    "price_eur": {"type": "integer"}
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- rebuild the mcp_server to follow OpenAI MCP guidelines
- load OpenAPI and plugin definitions from JSON files
- expose a fixed vehicle pricing table with fallback to random values
- update README with new usage details

## Testing
- `python -m py_compile services/mcp_server/app/*.py`
- `PYTHONPATH=services/mcp_server python -m uvicorn app.main:app --port 8000` *(started and stopped successfully)*

------
https://chatgpt.com/codex/tasks/task_e_684cbf806b68832cb8b37a55012333ec