### PR TITLE
Expose nginx on port 80

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ The table below lists the available services. Follow the links for detailed info
 | **handler** | `8082:8000` | `nginx`, `postgres` | [handler/README.md](services/handler/README.md) |
 | **postgres** | `5432:5432` | `nginx` | [postgres/README.md](services/postgres/README.md) |
 | **mcp_server** | `8090:8000` | `nginx` | [mcp_server/README.md](services/mcp_server/README.md) |
-| **nginx** | `8081:80` | - | [nginx/README.md](services/nginx/README.md) |
+| **nginx** | `80:80` | - | [nginx/README.md](services/nginx/README.md) |
+
+The Jenkins UI running on the host at port `8080` can be reached via `http://localhost/jenkins/` through the Nginx proxy.
 
 ### Persistent Storage
 

--- a/services/nginx/README.md
+++ b/services/nginx/README.md
@@ -1,12 +1,13 @@
 # Nginx Reverse Proxy
 
 This container runs a lightweight Nginx instance that forwards requests to the other services.
-It is built as `custom-nginx:latest` and exposes port **80** (published on the host as `8081`).
+It is built as `custom-nginx:latest` and exposes port **80** on the host.
 
 ## Routing
 
- - Requests to `/api/` are proxied to the **handler** service with the `/api` prefix removed.
+- Requests to `/api/` are proxied to the **handler** service with the `/api` prefix removed.
 - Requests to `/mcp/` are proxied to the **mcp_server** service.
+- Requests to `/jenkins/` are proxied to the host Jenkins instance on port `8080`.
 - Unknown paths return a custom `404.html` page.
 
 Access and error logs are written to `/var/ci_data/nginx/logs` on the host as defined in `deploy.json`.

--- a/services/nginx/deploy.json
+++ b/services/nginx/deploy.json
@@ -1,7 +1,7 @@
 {
   "image": "custom-nginx:latest",
   "build": true,
-  "ports": ["8081:80"],
+  "ports": ["80:80"],
   "volumes": {
     "/var/ci_data/nginx/logs": "/var/log/nginx"
   }

--- a/services/nginx/nginx.conf
+++ b/services/nginx/nginx.conf
@@ -39,6 +39,15 @@ server {
         proxy_set_header Connection "upgrade";
     }
 
+    # Proxy Jenkins running on the host
+    location /jenkins/ {
+        proxy_pass http://host.docker.internal:8080/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     # Direct access to MCP server (optional)
     location /mcp-direct/ {
         proxy_pass http://mcp_server:8000/;


### PR DESCRIPTION
## Summary
- expose nginx on host port 80
- document new /jenkins route
- update docs to reflect new port mapping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d43926d38832c84cb4af59274c801