### PR TITLE
Add tap game endpoint to handler

### DIFF
--- a/services/handler/README.md
+++ b/services/handler/README.md
@@ -21,6 +21,7 @@ This service depends on both the `nginx` and `postgres` containers, which must b
 - `GET /tools/echo2` – simple HTML response.
 - `POST /tools/messages` – store a message in the database and return its ID.
 - `GET /tools/messages/{id}` – retrieve a stored message by ID.
+- `GET /tools/game` – a small tap game for quick mobile testing.
 
 The application creates its database tables automatically on startup, retrying for a short period if the database is not yet ready.
 

--- a/services/handler/app/routes/tools.py
+++ b/services/handler/app/routes/tools.py
@@ -30,6 +30,59 @@ async def echo():
     </html>
     """
 
+@router.get("/game", response_class=HTMLResponse)
+async def tap_game() -> str:
+    """Serve a tiny tap game that works on mobile browsers."""
+    return """
+    <html>
+        <head>
+            <title>Tap Game</title>
+            <style>
+                body { font-family: Arial, sans-serif; text-align: center; }
+                #tap { font-size: 2em; padding: 1em 2em; }
+            </style>
+        </head>
+        <body>
+            <h1>Tap Game</h1>
+            <p>Tap the button as many times as you can in 10 seconds!</p>
+            <button id="tap" disabled>Tap!</button>
+            <div id="score">Score: 0</div>
+            <div id="timer"></div>
+            <script>
+                let score = 0;
+                let time = 10;
+                const btn = document.getElementById('tap');
+                const scoreEl = document.getElementById('score');
+                const timerEl = document.getElementById('timer');
+
+                function startGame() {
+                    score = 0;
+                    time = 10;
+                    scoreEl.textContent = 'Score: 0';
+                    timerEl.textContent = 'Time: ' + time;
+                    btn.disabled = false;
+                    const interval = setInterval(() => {
+                        time--;
+                        timerEl.textContent = 'Time: ' + time;
+                        if (time === 0) {
+                            clearInterval(interval);
+                            btn.disabled = true;
+                            timerEl.textContent = "Time's up!";
+                        }
+                    }, 1000);
+                }
+
+                btn.addEventListener('click', () => {
+                    score++;
+                    scoreEl.textContent = 'Score: ' + score;
+                });
+
+                window.onload = startGame;
+            </script>
+        </body>
+    </html>
+    """
+
 @router.post("/messages")
 async def create_message(req: ToolRequest, db: AsyncSession = Depends(get_db)):
     msg = Message(content=req.message)


### PR DESCRIPTION
## Summary
- add `/tools/game` endpoint with a simple tap game
- document new endpoint in handler README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b29cd00ac832c91b4c003613eb7cb