### PR TITLE
Add high score tracker to tap game

### DIFF
--- a/services/handler/README.md
+++ b/services/handler/README.md
@@ -22,6 +22,8 @@ This service depends on both the `nginx` and `postgres` containers, which must b
 - `POST /tools/messages` – store a message in the database and return its ID.
 - `GET /tools/messages/{id}` – retrieve a stored message by ID.
 - `GET /tools/game` – a small tap game for quick mobile testing.
+- `GET /tools/game/highscore` – return the current high score.
+- `POST /tools/game/highscore` – submit a score and update the record if higher.
 
 The application creates its database tables automatically on startup, retrying for a short period if the database is not yet ready.
 

--- a/services/handler/app/db.py
+++ b/services/handler/app/db.py
@@ -1,7 +1,7 @@
 import os
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker, DeclarativeBase, Mapped, mapped_column
-from sqlalchemy import Integer, Text
+from sqlalchemy import Integer, Text, select
 from sqlalchemy.exc import OperationalError
 import asyncio
 
@@ -21,12 +21,24 @@ class Message(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
     content: Mapped[str] = mapped_column(Text)
 
+
+class HighScore(Base):
+    __tablename__ = "highscores"
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    score: Mapped[int] = mapped_column(Integer, default=0)
+
 async def init_db(retries: int = 5, delay: float = 2) -> None:
     """Initialise database tables, retrying if the DB isn't ready yet."""
     for attempt in range(1, retries + 1):
         try:
             async with engine.begin() as conn:
                 await conn.run_sync(Base.metadata.create_all)
+            async with SessionLocal() as session:
+                result = await session.execute(select(HighScore))
+                hs = result.scalar_one_or_none()
+                if hs is None:
+                    session.add(HighScore(score=0))
+                    await session.commit()
             break
         except OperationalError:
             if attempt == retries:


### PR DESCRIPTION
## Summary
- create `HighScore` table and init entry on startup
- add backend API for getting and posting high scores
- extend tap game HTML to fetch and store high score
- document new endpoints in handler README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685bac9e9e60832c8b7d76748bbaa1f2