### PR TITLE
Fix timer for game endpoint

### DIFF
--- a/services/handler/app/routes/tools.py
+++ b/services/handler/app/routes/tools.py
@@ -74,7 +74,7 @@ async def tap_game() -> str:
                     timerEl.textContent = 'Time: ' + time;
                     btn.disabled = false;
                     refreshBtn.style.display = 'none';
-                    const interval = setInterval(() => {
+                    const interval = setInterval(async () => {
                         time--;
                         timerEl.textContent = 'Time: ' + time;
                         if (time === 0) {


### PR DESCRIPTION
## Summary
- start tap game timer using `async` interval

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685baec32c50832cab5c8448a7b53b68