### PR TITLE
Fix high score submission for handler game

### DIFF
--- a/services/handler/app/routes/tools.py
+++ b/services/handler/app/routes/tools.py
@@ -62,7 +62,7 @@ async def tap_game() -> str:
                 const timerEl = document.getElementById('timer');
 
                 async function fetchHighscore() {
-                    const res = await fetch('/tools/game/highscore');
+                    const res = await fetch('highscore');
                     if (res.ok) {
                         const data = await res.json();
                         highEl.textContent = 'High Score: ' + data.highscore;
@@ -87,7 +87,7 @@ async def tap_game() -> str:
                             refreshBtn.style.display = 'inline-block';
                             startBtn.style.display = 'inline-block';
                             try {
-                                const res = await fetch('/tools/game/highscore', {
+                                const res = await fetch('highscore', {
                                     method: 'POST',
                                     headers: { 'Content-Type': 'application/json' },
                                     body: JSON.stringify({ score })


### PR DESCRIPTION
## Summary
- fix fetch path in tap game to work whether served via nginx or directly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685bb2a599c4832cb41e39b4afd1a30a