### PR TITLE
Add homepage photo upload feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,5 @@ The table below lists the available services. Follow the links for detailed info
 
 ### Persistent Storage
 
-Containers store data in `/var/ci_data` on the host. For example the PostgreSQL data directory resides in `/var/ci_data/postgres/data` and Nginx logs are written to `/var/ci_data/nginx/logs`. All volume mappings are specified in `docker-compose.yml`.
+Containers store data in `/var/ci_data` on the host. For example the PostgreSQL data directory resides in `/var/ci_data/postgres/data`, uploaded homepage images are stored in `/var/ci_data/uploads`, and Nginx logs are written to `/var/ci_data/nginx/logs`. All volume mappings are specified in `docker-compose.yml`.
 

--- a/deploy-script.sh
+++ b/deploy-script.sh
@@ -31,12 +31,13 @@ echo "📁 Creating data directories..."
 sudo mkdir -p /var/ci_data/postgres/data
 sudo mkdir -p /var/ci_data/nginx/logs
 sudo mkdir -p /var/ci_data/mcp_server/logs
+sudo mkdir -p /var/ci_data/uploads
 
 # Ensure PostgreSQL can access its data directory (UID 999 inside the container)
 sudo chown -R 999:999 /var/ci_data/postgres
 
 # The other directories can be owned by the deploying user
-sudo chown -R $USER:$USER /var/ci_data/nginx/logs /var/ci_data/mcp_server/logs
+sudo chown -R $USER:$USER /var/ci_data/nginx/logs /var/ci_data/mcp_server/logs /var/ci_data/uploads
 
 # Update docker-compose.yml with correct registry/Remote_host
 sed -i "s/\${DOCKER_REGISTRY}/$DOCKER_REGISTRY/g" docker-compose.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - "80:80"
     volumes:
       - /var/ci_data/nginx/logs:/var/log/nginx
+      - /var/ci_data/uploads:/usr/share/nginx/html/uploads
     networks:
       - ci-network
     restart: unless-stopped
@@ -36,6 +37,9 @@ services:
     environment:
       GLOBAL_MESSAGE: "Hello from Jenkins!!"
       DATABASE_URL: "postgresql+asyncpg://postgres:postgres@postgres:5432/handler_db"
+      HOMEPAGE_PATH: "/uploads/homepage.jpg"
+    volumes:
+      - /var/ci_data/uploads:/uploads
     networks:
       - ci-network
     restart: unless-stopped

--- a/services/handler/README.md
+++ b/services/handler/README.md
@@ -24,6 +24,7 @@ This service depends on both the `nginx` and `postgres` containers, which must b
 - `GET /tools/game` – a small tap game for quick mobile testing.
 - `GET /tools/game/highscore` – return the current high score.
 - `POST /tools/game/highscore` – submit a score and update the record if higher.
+- `POST /tools/homepage` – upload an image to be served at the site root.
 
 The application creates its database tables automatically on startup, retrying for a short period if the database is not yet ready.
 

--- a/services/handler/app/routes/tools.py
+++ b/services/handler/app/routes/tools.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, File
+import os
 from fastapi.responses import HTMLResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
@@ -155,3 +156,16 @@ async def read_message(msg_id: int, db: AsyncSession = Depends(get_db)):
     if not msg:
         raise HTTPException(status_code=404, detail="Message not found")
     return {"id": msg.id, "message": msg.content}
+
+
+HOMEPAGE_PATH = os.getenv("HOMEPAGE_PATH", "/uploads/homepage.jpg")
+
+
+@router.post("/homepage")
+async def upload_homepage(file: UploadFile = File(...)):
+    """Upload an image that will be served at the site root."""
+    data = await file.read()
+    os.makedirs(os.path.dirname(HOMEPAGE_PATH), exist_ok=True)
+    with open(HOMEPAGE_PATH, "wb") as f:
+        f.write(data)
+    return {"status": "uploaded"}

--- a/services/nginx/README.md
+++ b/services/nginx/README.md
@@ -9,6 +9,7 @@ Jenkins builds the image from this directory and tags it as `${DOCKER_REGISTRY}/
 - Requests to `/mcp/` are proxied to the **mcp_server** service.
 - Requests to `/jenkins/` are proxied to the host Jenkins instance on port `8080`.
 - Unknown paths return a custom `404.html` page.
+- The site root `/` serves the uploaded homepage image if present.
 
 Access and error logs are written to `/var/ci_data/nginx/logs` on the host as defined in `docker-compose.yml`.
 This container has no dependencies, but other services rely on it for routing.

--- a/services/nginx/nginx.conf
+++ b/services/nginx/nginx.conf
@@ -52,8 +52,8 @@ server {
         internal;
     }
 
-    location / {
-        return 302 /404;  # temporary redirect for unknown paths
+    location = / {
+        try_files /uploads/homepage.jpg /404.html;
     }
 
     location = /404 {


### PR DESCRIPTION
## Summary
- allow uploading a homepage image through the handler
- serve uploaded image from nginx at `/`
- persist uploaded files using a new shared volume
- document new endpoint and storage path
- create upload directory during deployment

## Testing
- `python3 -m py_compile services/handler/app/routes/tools.py`


------
https://chatgpt.com/codex/tasks/task_e_68603b441dcc832c90385cde30e15b6c